### PR TITLE
Korrektes Singular bei Nachrichten

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -101,12 +101,12 @@ ipcMain.handle("unread_notifications", (event, data) => {
 
   if(showedUnread || unreadNotifications <= 0 || unreadChatMessages <= 0) return
   const message =
-      unreadNotifications <= 0 ? `Du hast ${unreadChatMessages} ungelesenen Chatnachrichten`
-      : unreadChatMessages <= 0 ? `Du hast ${unreadNotifications} neue Benachrichtigungen`
-      : `Du hast ${unreadChatMessages} ungelesenen Chat-Nachrichten und ${unreadNotifications} neue Benachrichtigungen`
+      unreadNotifications <= 0 ? `Du hast ${unreadChatMessages} ungelesene Chatnachricht${unreadChatMessages==1?"":"en"}`
+      : unreadChatMessages <= 0 ? `Du hast ${unreadNotifications} neue Benachrichtigung${unreadNotifications==1?"":"en"}`
+      : `Du hast ${unreadChatMessages} ungelesene Chat-Nachricht${unreadChatMessages==1?"":"en"} und ${unreadNotifications} neue Benachrichtigung${unreadNotifications==1?"":"en"}`
 
   new Notification({
-    title: "Ungelesene Nachrichten",
+    title: `Ungelesene Nachricht${unreadChatMessages + unreadNotifications == 1 ? "" : "en"}`,
     body: message,
     urgency: "low",
   }).show()


### PR DESCRIPTION
Bei ungelesenen Nachrichten wird nun im Body ein korrektes Singular verwendet.
Fixt #72

Vorher:
`Du hast 1 ungelesenen Chat-Nachrichten und 1 neue Benachrichtigungen`
`Du hast 1 neue Benachrichtigungen`
`Du hast 1 ungelesenen Chatnachrichten`
`Du hast 1 ungelesenen Chat-Nachrichten und 2 neue Benachrichtigungen`

Nachher:
`Du hast 1 ungelesene Chat-Nachricht und 1 neue Benachrichtigung`
`Du hast 1 neue Benachrichtigung`
`Du hast 1 ungelesene Chatnachricht`
`Du hast 1 ungelesene Chat-Nachricht und 2 neue Benachrichtigungen`

Ebenso im Titel:
Bei 1 Nachricht: `Ungelesene Nachricht`
Bei mehr als 2: `Ungelesene Nachrichten`